### PR TITLE
Add check on destroy (Menu can be empty)

### DIFF
--- a/src/jquery.contextMenu.js
+++ b/src/jquery.contextMenu.js
@@ -1592,6 +1592,10 @@
                     // get proper options
                     var context = o.context;
                     $.each(menus, function (ns, o) {
+                        
+                        if (!o) {
+                            return true;
+                        }
 
                         // Is this menu equest to the context called from
                         if (!$(context).is(o.selector)) {


### PR DESCRIPTION
In my app, sometimes menu is empty (i.e. [o param is empty](https://github.com/swisnl/jQuery-contextMenu/blob/master/src/jquery.contextMenu.js#L1658)), i think this condition it will not be superfluous
